### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,8 @@
 name: Build and Release APK
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [closed]
@@ -10,6 +13,8 @@ on:
 jobs:
   build:
     name: Build APK
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
 


### PR DESCRIPTION
Potential fix for [https://github.com/udyan-dev/torfin/security/code-scanning/1](https://github.com/udyan-dev/torfin/security/code-scanning/1)

To fix the problem, explicitly declare a `permissions` block in the workflow file. The minimal secure option is to set `permissions: contents: read` at the root (applies to all jobs), and then, for jobs/actions that require higher permissions (such as publishing a release), elevate only those specifically as needed. In this case, since the workflow uses `softprops/action-gh-release`, which needs `contents: write` to create GitHub releases, the cleanest and most secure solution is:

- At the root of `.github/workflows/build-release.yml` (after `name:` and before `on:`), add a block:
  ```yaml
  permissions:
    contents: read
  ```
- For the `build` job, since the GitHub release step requires greater rights, override with:
  ```yaml
    permissions:
      contents: write
  ```
  just under `build:` in the `jobs:` block.

If only the `build` job exists and all its steps need some write access (e.g., to create releases), just adding `permissions: contents: write` directly in the job suffices.  
However, following the least privilege principle, the root workflow should have `read` permissions, and the job needing more should be explicitly elevated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
